### PR TITLE
Clear trigger log contents on every event

### DIFF
--- a/komand/trigger.py
+++ b/komand/trigger.py
@@ -28,3 +28,6 @@ class Trigger(Step):
             'version': 'v1',
         }
         self.dispatcher.write(msg)
+
+        # Clear the log contents for the next event
+        self.log_stream.truncate(0)


### PR DESCRIPTION
Otherwise each event's log is going to contain the logs of the previous event.

This isn't a problem with actions because each action/trigger gets its own logger