### PR TITLE
SDK Update: fix reserved variables in Connection 

### DIFF
--- a/komand/connection.py
+++ b/komand/connection.py
@@ -33,17 +33,16 @@ class ConnectionCache(object):
 
         conn = copy.copy(self.prototype)
         conn.logger = logger
-        conn.set(parameters)
+        conn.set_(parameters)
         # i don't know why this is needed twice..
         # i think for backwards compat reasons
         conn.connect(parameters)
-        self.connections[conn.key()] = conn
+        self.connections[conn.key_()] = conn
         return conn
 
 
 class Connection(object):
     """Komand connection"""
-
     def __init__(self, input):
         # Maintain backwards compatibility here - if Input object passed in it will have a 'schema' property so use that
         # Otherwise, the input is a JSON schema, so just use it directly
@@ -54,11 +53,11 @@ class Connection(object):
         self.parameters = {}
         self.logger = None
 
-    def key(self):
+    def key_(self):
         """key is a unique connection key"""
         return key(self.parameters)
 
-    def set(self, parameters):
+    def set_(self, parameters):
         """ Set parameters """
         self.parameters = parameters
         self._validate()


### PR DESCRIPTION
'str' object not callable when you use variables reserved in SDK in your plugin code.
Renamed variables in the Connection class 

```
./bin/komand_sdk_print run < tests/print_string.json
{"body": {"log": "", "status": "ok", "meta": {}, "output": {"results": "My Test string to be printed"}}, "version": "v1", "type": "action_event"}root@e18c894a2080:/python/src#
```
Test JSON used
```
{
  "body": {
    "action": "print_string",
    "meta": {},
    "input": {
      "content": "My Test string to be printed"
    },
    "connection": {
      "api": "en_US",
      "key": "123321"
    }
  },
  "type": "action_start",
  "version": "v1"
}
```