### PR TITLE
Debug Enhancement | added debug command argument for better debugging

### DIFF
--- a/komand/cli.py
+++ b/komand/cli.py
@@ -139,7 +139,7 @@ class CLI(object):
     def run_step(self, args):
         return self.execute_step(is_test=False, is_debug=args.debug)
 
-    def debug_step(self,args):
+    def debug_step(self, args):
         if args.file:
             with open(args.file, 'r') as f:
                 debug_file = json.load(f)


### PR DESCRIPTION
Debugging the SDK or a plugin before this change was complicated. With this  addition debugging can take place in PDB or Pycharms Run/Debug with little configuration. 

Example:
```
./komand_base64 debug --file ../tests/decode.json
{"body": {"log": "", "status": "ok", "meta": {}, "output": {"data": "hey,this,is,cool,right\ntell,me,what,you,think\n"}}, "version": "v1", "type": "action_event"}%   
```

The new argument takes `--file` with the location of the JSON test file after it.