### PR TITLE
Add null/empty string validation for required fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ test:
 
 tag: image
 	@echo version is $(VERSION)
-	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin:$(VERSION)
-	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin:$(MINOR_VERSION)
-	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin:$(MAJOR_VERSION)
+	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin-test-null:$(VERSION)
+	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin-test-null:$(MINOR_VERSION)
+	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin-test-null:$(MAJOR_VERSION)
 
 deploy: tag
 	@echo docker login -u "********" -p "********"

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ tag: image
 deploy: tag
 	@echo docker login -u "********" -p "********"
 	@docker login -u $(KOMAND_DOCKER_USERNAME) -p $(KOMAND_DOCKER_PASSWORD)
-	docker push komand/python-$(DOCKERFILE)-plugin
-	docker push komand/python-$(DOCKERFILE)-plugin:$(VERSION)
-	docker push komand/python-$(DOCKERFILE)-plugin:$(MINOR_VERSION)
-	docker push komand/python-$(DOCKERFILE)-plugin:$(MAJOR_VERSION)
+	docker push komand/python-$(DOCKERFILE)-plugin-test-null
+	docker push komand/python-$(DOCKERFILE)-plugin-test-null:$(VERSION)
+	docker push komand/python-$(DOCKERFILE)-plugin-test-null:$(MINOR_VERSION)
+	docker push komand/python-$(DOCKERFILE)-plugin-test-null:$(MAJOR_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,14 @@ test:
 
 tag: image
 	@echo version is $(VERSION)
-	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin-test-null:$(VERSION)
-	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin-test-null:$(MINOR_VERSION)
-	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin-test-null:$(MAJOR_VERSION)
+	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin:$(VERSION)
+	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin:$(MINOR_VERSION)
+	docker tag komand/python-$(DOCKERFILE)-plugin komand/python-$(DOCKERFILE)-plugin:$(MAJOR_VERSION)
 
 deploy: tag
 	@echo docker login -u "********" -p "********"
 	@docker login -u $(KOMAND_DOCKER_USERNAME) -p $(KOMAND_DOCKER_PASSWORD)
-	docker push komand/python-$(DOCKERFILE)-plugin-test-null
-	docker push komand/python-$(DOCKERFILE)-plugin-test-null:$(VERSION)
-	docker push komand/python-$(DOCKERFILE)-plugin-test-null:$(MINOR_VERSION)
-	docker push komand/python-$(DOCKERFILE)-plugin-test-null:$(MAJOR_VERSION)
+	docker push komand/python-$(DOCKERFILE)-plugin
+	docker push komand/python-$(DOCKERFILE)-plugin:$(VERSION)
+	docker push komand/python-$(DOCKERFILE)-plugin:$(MINOR_VERSION)
+	docker push komand/python-$(DOCKERFILE)-plugin:$(MAJOR_VERSION)

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -274,6 +274,11 @@ class Plugin(object):
         except Exception as e:
             raise Exception('Unable to validate {} input JSON'.format(step_key), e)
 
+        # Validate required inputs
+        # Step inputs will be checked against schema for required properties existence
+        # This is needed to prevent null/empty string values from being passed as output to input of steps
+        step.input.validate_required(params)
+
         if is_test:
             func = step.test
         else:

--- a/komand/variables.py
+++ b/komand/variables.py
@@ -34,8 +34,6 @@ class Input(object):
                                     "Please contact support for assistance.\n"
                                     "Empty string input was: %s" % key)
 
-                # and not parameters[key]:
-
     def sample(self):
         """ Sample object """
         return util.sample(self.schema)

--- a/komand/variables.py
+++ b/komand/variables.py
@@ -32,13 +32,10 @@ class Input(object):
         :return: None
         """
         required = "required"
-        message = """
-        Step error: Plugin step input contained a null value or empty string in a required input.\n
-        If the input was given a variable in the Workflow Builder, please double-check that the variable contained a 
-        value at run-time. If the input had a valid value and the issue persists, please contact support for 
-        assistance.\n
-        Invalid input was found in: {key}        
-        """
+        message = "Step error: Plugin step input contained a null value or empty string in a required input.\n" \
+                  "If the input was given a variable in the Workflow Builder, please double-check that the variable " \
+                  "contained a value at run-time. If the input had a valid value and the issue persists, " \
+                  "please contact support for assistance.\nInvalid input was found in: {key}"
 
         # Early return if there's nothing for this function to do
         if required not in self.schema:

--- a/komand/variables.py
+++ b/komand/variables.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from jsonschema import validate
-
 import komand.util as util
 
 
@@ -20,6 +19,22 @@ class Input(object):
     def validate(self, parameters):
         """ Validate variables """
         validate(parameters, self.schema)
+
+    def validate_required(self, parameters):
+        required_inputs = self.schema["required"]
+
+        for key in parameters:
+            if key in required_inputs:
+                if parameters[key] is None:  # Check for null
+                    raise Exception("Step error: Plugin step contained a null value in a required input.\n"
+                                    "Please contact support for assistance.\n"
+                                    "Missing input was: %s" % key)
+                elif isinstance(parameters[key], str) and not parameters[key]:  # Check for 0-length strings
+                    raise Exception("Step error: Plugin step contained an empty string in a required input.\n"
+                                    "Please contact support for assistance.\n"
+                                    "Empty string input was: %s" % key)
+
+                # and not parameters[key]:
 
     def sample(self):
         """ Sample object """

--- a/komand/variables.py
+++ b/komand/variables.py
@@ -27,6 +27,7 @@ class Input(object):
         """
         Validates required input parameters for invalid values (null, empty string) and raises an Exception in their
         presence.
+        In the future, this should probably be built into an existing JSONSchema validator
         :param parameters: Input parameters
         :return: None
         """

--- a/komand/variables.py
+++ b/komand/variables.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from jsonschema import validate
 import komand.util as util
+import logging
 
 
 class Input(object):
@@ -27,6 +28,7 @@ class Input(object):
         :param parameters: Input parameters
         :return: None
         """
+        logging.info("VALIDATING REQUIRED FIELDS!!!")
         required_inputs = self.schema["required"]
 
         for key in parameters:

--- a/komand/variables.py
+++ b/komand/variables.py
@@ -46,15 +46,15 @@ class Input(object):
 
         required_inputs = self.schema[required]  # List of required inputs, pulled from the jsonschema
 
-        # Iterate over all parameters (inputs, k:v pairs) with just the key to check for presence in the list
-        # of required inputs from above. If it is, then check if the value is "valid" according to our guidelines
+        # Iterate over parameters (inputs, k:v pairs) with the key to check for presence in the list
+        # of required inputs from above. If present, check the value is "valid" according to our guidelines
         # (no null values, no empty strings). Note that the InsightConnect UI seems to mutate null values
         # into empty strings. Retain the null check as it is possible this behavior changes in future iterations.
         for key in parameters:
             if key in required_inputs:
                 value = parameters[key]
 
-                # Check if the value is None/null OR the value is a string and has a length of 0
+                # Check if the value is null OR the value is a string and has a length of 0
                 # Logic is expanded due to the fact that we don't want to false-positive on False boolean values
                 if (value is None) or (isinstance(value, string_types) and not len(value)):
                     raise ClientException(message.format(key=key))

--- a/komand/variables.py
+++ b/komand/variables.py
@@ -2,6 +2,8 @@
 from jsonschema import validate
 import komand.util as util
 import logging
+from komand.exceptions import ClientException
+from six import string_types  # Needed for Py2/3 string-type validation
 
 
 class Input(object):
@@ -28,19 +30,26 @@ class Input(object):
         :param parameters: Input parameters
         :return: None
         """
-        logging.info("VALIDATING REQUIRED FIELDS!!!")
-        required_inputs = self.schema["required"]
+        required = "required"
+
+        # Early return if there's nothing for this function to do
+        if required not in self.schema:
+            return
+
+        required_inputs = self.schema[required]
 
         for key in parameters:
             if key in required_inputs:
-                if parameters[key] is None:  # Check for null
-                    raise Exception("Step error: Plugin step contained a null value in a required input.\n"
-                                    "Please contact support for assistance.\n"
-                                    "Missing input was: %s" % key)
-                elif isinstance(parameters[key], str) and not parameters[key]:  # Check for 0-length strings
-                    raise Exception("Step error: Plugin step contained an empty string in a required input.\n"
-                                    "Please contact support for assistance.\n"
-                                    "Empty string input was: %s" % key)
+                value = parameters[key]
+
+                if value is None:  # Check for null
+                    raise ClientException("Step error: Plugin step contained a null value in a required input.\n"
+                                          "Please contact support for assistance.\n"
+                                          "Missing input was: %s" % key)
+                elif isinstance(value, string_types) and not len(value):  # Check for 0-length strings
+                    raise ClientException("Step error: Plugin step contained an empty string in a required input.\n"
+                                          "Please contact support for assistance.\n"
+                                          "Empty string input was: %s" % key)
 
     def sample(self):
         """ Sample object """

--- a/komand/variables.py
+++ b/komand/variables.py
@@ -21,6 +21,12 @@ class Input(object):
         validate(parameters, self.schema)
 
     def validate_required(self, parameters):
+        """
+        Validates required input parameters for invalid values (null, empty string) and raises an Exception in their
+        presence.
+        :param parameters: Input parameters
+        :return: None
+        """
         required_inputs = self.schema["required"]
 
         for key in parameters:


### PR DESCRIPTION
Tested working in the UI with the `whois` and `base64` plugins. Py2/3/PyPy3.
Tested and works as expected for string and bytes types.

<img width="615" alt="screen shot 2018-09-19 at 5 03 12 pm" src="https://user-images.githubusercontent.com/32079048/45784625-1a911280-bc2f-11e8-878f-f0c8673315d9.png">

<img width="614" alt="screen shot 2018-09-20 at 10 30 32 am" src="https://user-images.githubusercontent.com/32079048/45829329-50caa280-bcc0-11e8-8566-ab94f0a4a2c7.png">

<img width="611" alt="screen shot 2018-09-20 at 11 13 50 am" src="https://user-images.githubusercontent.com/32079048/45831993-4f9c7400-bcc6-11e8-8498-d8860cb0446f.png">
