### PR TITLE
DF-1966: Utilize connection test when available

### DIFF
--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -279,8 +279,14 @@ class Plugin(object):
         # This is needed to prevent null/empty string values from being passed as output to input of steps
         step.input.validate_required(params)
 
+        was_connection_test = False
         if is_test:
-            func = step.test
+            # Check if connection test func available. If so - use it (preferred). Else fallback to action/trigger test
+            if hasattr(step.connection, "test"):
+                was_connection_test = True
+                func = step.connection.test
+            else:
+                func = step.test
         else:
             func = step.run
 
@@ -300,6 +306,7 @@ class Plugin(object):
             else:
                 output = func()
 
-        step.output.validate(output)
+        if not was_connection_test:
+            step.output.validate(output)
 
         return output


### PR DESCRIPTION
This change updates the SDK to utilize the test function located in "connection.py" if it exists, rather than using the test function located in each action/trigger. In addition this will skip output validation for a connection test, removing the need to do any complex returns to force each test to pass.

Test evidence (working properly in product and CLI):
<img width="715" alt="screen shot 2018-11-21 at 7 26 56 pm" src="https://user-images.githubusercontent.com/32079048/48876404-87f22880-edc3-11e8-8926-78932f1d98fa.png">
<img width="491" alt="screen shot 2018-11-21 at 7 27 09 pm" src="https://user-images.githubusercontent.com/32079048/48876405-888abf00-edc3-11e8-95f5-28d289678120.png">
<img width="1222" alt="screen shot 2018-11-21 at 7 27 17 pm" src="https://user-images.githubusercontent.com/32079048/48876406-888abf00-edc3-11e8-94f9-e76dc548c807.png">
<img width="852" alt="screen shot 2018-11-21 at 7 33 41 pm" src="https://user-images.githubusercontent.com/32079048/48983599-4b217c80-f0b6-11e8-9e9b-511f100119f7.png">
