### PR TITLE
DF-1966: Update test function signature to better reflect changes

### DIFF
--- a/komand/step.py
+++ b/komand/step.py
@@ -23,5 +23,8 @@ class Step(object):
         raise NotImplementedError
 
     def test(self, params={}):
-        """ Test an action, return output or raise error"""
-        raise NotImplementedError
+        """
+        Test an action, return output or raise error
+        Deprecated in favor of using the test function in the plugin Connection file
+        """
+        pass

--- a/komand/step.py
+++ b/komand/step.py
@@ -25,6 +25,6 @@ class Step(object):
     def test(self, params={}):
         """
         Test an action, return output or raise error
-        Deprecated in favor of using the test function in the plugin Connection file
+        Deprecated in favor of using the test function in the plugin connection.py file
         """
         pass


### PR DESCRIPTION
This PR updates the test function signature in a step (action/trigger) to better reflect the changes introduced by the last PR (prefer connection test over step test). 

The previous PR functionally works A-OK as the test function will be defined in either connection or step, and therefore cannot raise the "NotImplementedError" - however, it is no longer necessary to raise a NotImplementedError in the instance that the test does not exist in a step.

This PR just cleans things up a bit.