### PR TITLE
DF-2000: Ignore Test Output Validation

### DIFF
--- a/komand/cli.py
+++ b/komand/cli.py
@@ -31,7 +31,7 @@ class CLI(object):
     Server mode:
      - the 'http' parameter starts the plugin in server mode
      - HTTP POST requests replace the stdin/stdout communication
-
+     - test mode is set via path component, ie. POST host:port/actions/action_name/test
     """
 
     def __init__(self, plugin, args=sys.argv[1:]):

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -279,11 +279,9 @@ class Plugin(object):
         # This is needed to prevent null/empty string values from being passed as output to input of steps
         step.input.validate_required(params)
 
-        was_connection_test = False
         if is_test:
             # Check if connection test func available. If so - use it (preferred). Else fallback to action/trigger test
             if hasattr(step.connection, "test"):
-                was_connection_test = True
                 func = step.connection.test
             else:
                 func = step.test
@@ -306,7 +304,9 @@ class Plugin(object):
             else:
                 output = func()
 
-        if not was_connection_test:
+        # Don't validate output for any test functions - action/trigger tests shouldn't be validated due to them
+        # not providing value and a connection test shouldn't be validated due to it being generic/universal
+        if not is_test:
             step.output.validate(output)
 
         return output


### PR DESCRIPTION
This PR updates the Python SDK to disable validation against test function output. Backwards compatibility is maintained.

Test Evidence:
Using test function within an action. All output properties on the action set to required. Test function returns empty dict as output, therefore it should still pass. It does. Running action in non-test mode still fails (as expected due to all properties being required). Test passes fine (as expected) in Komand UI.

![screen shot 2018-12-05 at 2 25 32 pm](https://user-images.githubusercontent.com/32079048/49541937-c4308900-f899-11e8-919e-7cb7c7e301b0.png)
![screen shot 2018-12-05 at 2 25 44 pm](https://user-images.githubusercontent.com/32079048/49541938-c4308900-f899-11e8-91d2-7057a773ed07.png)
<img width="775" alt="screen shot 2018-12-05 at 2 26 01 pm" src="https://user-images.githubusercontent.com/32079048/49541940-c4308900-f899-11e8-9e15-c8595e3a1972.png">
![screen shot 2018-12-05 at 3 12 51 pm](https://user-images.githubusercontent.com/32079048/49544415-6d7a7d80-f8a0-11e8-8198-a4737b641a21.png)
