### PR TITLE
DF-2009: Enforce Webserver Test Contract

### DIFF
--- a/komand/server.py
+++ b/komand/server.py
@@ -59,6 +59,10 @@ class PluginServer(gunicorn.app.base.BaseApplication):
             if input_message is None:
                 return abort(400)
 
+            # Enforce contract where path component MUST be "test"
+            if (test is not None) and (test.lower() != "test"):
+                return abort(400)
+
             # Ensure url matches action/trigger name in body
             if prefix == 'actions':
                 if input_message.get('body', {}).get('action', None) != name:


### PR DESCRIPTION
This PR enforces the requirement for the "test" path component (to activate test mode) to be "test", bringing functionality to that of the Go SDK.

Test evidence:
Normal run works OK. Normal test works OK. POST using a path with a non-"test" value as the last component throws a 400 as expected.
![screen shot 2018-12-05 at 2 56 58 pm](https://user-images.githubusercontent.com/32079048/49543618-4cb12880-f89e-11e8-8f1b-9ebf2001a213.png)
![screen shot 2018-12-05 at 2 58 21 pm](https://user-images.githubusercontent.com/32079048/49543619-4cb12880-f89e-11e8-8b3d-4ecf46b1d95b.png)
