### PR TITLE
DF-2143 | Enable access to metadata passed to a plugin

### DIFF
--- a/komand/cli.py
+++ b/komand/cli.py
@@ -118,8 +118,9 @@ class CLI(object):
 
         raise ValueError('Invalid trigger or action name.')
 
-    def execute_step(self, is_test=False, is_debug=False):
-        msg = self.plugin.unmarshal(sys.stdin)
+    def execute_step(self, is_test=False, is_debug=False, msg=None):
+        if not msg:
+            msg = self.plugin.unmarshal(sys.stdin)
         exception = None
         try:
             output = self.plugin.handle_step(msg, is_test=is_test, is_debug=is_debug)

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -41,7 +41,24 @@ message_output_type = {
 
 class Workflow(object):
 
-    def __init__(self, shortOrgId=None ,orgProductToken=None, uiHostUrl=None, jobId=None, stepId=None,versionId=None, nextStepId=None, nextEdgeId=None, triggerId=None, jobExecutionContextId=None, time=None, connectionTestId=None, connectionTestTimeout=None, workflowUID=None, stepUID=None, input_message=None):
+    def __init__(self, shortOrgId=None, orgProductToken=None, uiHostUrl=None, jobId=None, stepId=None, versionId=None, nextStepId=None, nextEdgeId=None, triggerId=None, jobExecutionContextId=None, time=None, connectionTestId=None, connectionTestTimeout=None, workflowId=None):
+        """
+
+        :param shortOrgId: Short version of the Organization ID
+        :param orgProductToken: Organization Product Token
+        :param uiHostUrl: Job URL for triggers
+        :param jobId: Job UUID
+        :param stepId: Step UUID
+        :param versionId:  Workflow Version UUID
+        :param nextStepId: Next Step UUID
+        :param nextEdgeId: Next Edge UUID
+        :param triggerId: Trigger UUID
+        :param jobExecutionContextId: Job Execution Context UUID
+        :param time: Time the action or trigger was executed
+        :param connectionTestId: Connection Test ID
+        :param connectionTestTimeout: Connection Test Timeout
+        :param workflowId: Workflow ID
+        """
         self.shortOrgId = shortOrgId
         self.orgProductToken = orgProductToken
         self.uiHostUrl = uiHostUrl
@@ -55,14 +72,12 @@ class Workflow(object):
         self.time = time
         self.connectionTestId = connectionTestId
         self.connectionTestTimeout = connectionTestTimeout
-        self.workflowUID = workflowUID
-        self.stepUID = stepUID
-        self.input_message = input_message
+        self.workflowId = workflowId
 
     @classmethod
     def from_komand(cls, input_message):
-        return cls(workflowUID=input_message.get("workflow_uid", None),
-                   stepUID=input_message.get("step_uid", None),
+        return cls(workflowId=input_message.get("workflow_uid", None),
+                   stepId=input_message.get("step_uid", None),
                    versionId=input_message.get("workflow_version_uid", None)
                    )
 
@@ -81,7 +96,6 @@ class Workflow(object):
                    time=input_message.get("time", None),
                    connectionTestId=input_message.get("connectionTestId", None),
                    connectionTestTimeout=input_message.get("connectionTestTimeout", None),
-                   input_message=input_message
                    )
 
 
@@ -92,7 +106,6 @@ class Meta(object):
         self.name, self.vendor, self.description, self.version, self.workflow = name, vendor, description, version, workflow
 
     def set_workflow(self, input_message):
-        # if connect or komand call from
         if input_message.get("workflow_uid"):
             self.workflow = Workflow.from_komand(input_message)
         else:
@@ -237,7 +250,7 @@ class Plugin(object):
         :param is_debug:
         :return:
         """
-        self.connection.meta.set_workflow(input_message)
+        self.connection.meta.set_workflow(input_message['body'].get('meta', None))
         request_id = uuid.uuid4()
         log_stream = stream_class()
         stream_handler = logging.StreamHandler(log_stream)

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -43,7 +43,11 @@ message_output_type = {
 
 class Workflow(object):
 
-    def __init__(self, shortOrgId=None, orgProductToken=None, uiHostUrl=None, jobId=None, stepId=None, versionId=None, nextStepId=None, nextEdgeId=None, triggerId=None, jobExecutionContextId=None, time=None, connectionTestId=None, connectionTestTimeout=None, workflowId=None):
+    def __init__(self, shortOrgId=None, orgProductToken=None, uiHostUrl=None,
+                 jobId=None, stepId=None, versionId=None, nextStepId=None,
+                 nextEdgeId=None, triggerId=None, jobExecutionContextId=None,
+                 time=None, connectionTestId=None, connectionTestTimeout=None,
+                 workflowId=None):
         """
         Worflow object for the Meta Class
         :param shortOrgId: Short version of the Organization ID
@@ -109,7 +113,7 @@ class Meta(object):
     def __init__(self, name='', vendor='', description='', version='',
                  workflow=None):
         self.name, self.vendor, self.description, self.version, \
-        self.workflow = name, vendor, description, version, workflow
+            self.workflow = name, vendor, description, version, workflow
 
     def set_workflow(self, input_message):
         """

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -98,10 +98,6 @@ class Meta(object):
         else:
             self.workflow = Workflow.from_insight_connect(input_message)
 
-
-
-
-
         
 class Plugin(object):
     """A Komand Plugin."""
@@ -122,7 +118,6 @@ class Plugin(object):
         self.debug = False
         self.custom_decoder = custom_decoder
         self.custom_encoder = custom_encoder
-
 
     def add_trigger(self, trigger):
         """ add a new trigger """
@@ -256,7 +251,6 @@ class Plugin(object):
         out_type = None
 
         try:
-
             # Attempt to grab message type first
             message_type = input_message.get('type')
             out_type = message_output_type.get(message_type)

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -104,7 +104,7 @@ class Workflow(object):
 class Meta(object):
     """ Meta properties for a plugin """
 
-    def __init__(self, name='', vendor='', description='', version='', workflow: Workflow=None):
+    def __init__(self, name='', vendor='', description='', version='', workflow=None):
         self.name, self.vendor, self.description, self.version, self.workflow = name, vendor, description, version, workflow
 
     def set_workflow(self, input_message):

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -43,7 +43,7 @@ class Workflow(object):
 
     def __init__(self, shortOrgId=None, orgProductToken=None, uiHostUrl=None, jobId=None, stepId=None, versionId=None, nextStepId=None, nextEdgeId=None, triggerId=None, jobExecutionContextId=None, time=None, connectionTestId=None, connectionTestTimeout=None, workflowId=None):
         """
-
+        Worflow object for the Meta Class
         :param shortOrgId: Short version of the Organization ID
         :param orgProductToken: Organization Product Token
         :param uiHostUrl: Job URL for triggers
@@ -76,6 +76,7 @@ class Workflow(object):
 
     @classmethod
     def from_komand(cls, input_message):
+        """Creates a Workflow object from Komand"""
         return cls(workflowId=input_message.get("workflow_uid", None),
                    stepId=input_message.get("step_uid", None),
                    versionId=input_message.get("workflow_version_uid", None)
@@ -83,6 +84,7 @@ class Workflow(object):
 
     @classmethod
     def from_insight_connect(cls, input_message):
+        """Creates a Workflow object from Insight Connect"""
         return cls(shortOrgId=input_message.get("shortOrgId", None),
                    orgProductToken=input_message.get("orgProductToken", None),
                    uiHostUrl=input_message.get("uiHostUrl", None),
@@ -106,6 +108,11 @@ class Meta(object):
         self.name, self.vendor, self.description, self.version, self.workflow = name, vendor, description, version, workflow
 
     def set_workflow(self, input_message):
+        """
+        Sets the workflow attribute within the Meta class
+        :param input_message:
+        :return:
+        """
         if input_message.get("workflow_uid"):
             self.workflow = Workflow.from_komand(input_message)
         else:

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -118,7 +118,7 @@ class Meta(object):
         # Python 2
         if version_info[0] == 2:
             new_input_message = {}
-            for k,v in input_message.items():
+            for k, v in input_message.items():
                 if isinstance(v, six.text_type):
                     new_input_message[k] = str(v)
                 else:

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -40,6 +40,7 @@ message_output_type = {
     'trigger_start': 'trigger_event',
 }
 
+
 class Workflow(object):
 
     def __init__(self, shortOrgId=None, orgProductToken=None, uiHostUrl=None, jobId=None, stepId=None, versionId=None, nextStepId=None, nextEdgeId=None, triggerId=None, jobExecutionContextId=None, time=None, connectionTestId=None, connectionTestTimeout=None, workflowId=None):
@@ -105,8 +106,10 @@ class Workflow(object):
 class Meta(object):
     """ Meta properties for a plugin """
 
-    def __init__(self, name='', vendor='', description='', version='', workflow=None):
-        self.name, self.vendor, self.description, self.version, self.workflow = name, vendor, description, version, workflow
+    def __init__(self, name='', vendor='', description='', version='',
+                 workflow=None):
+        self.name, self.vendor, self.description, self.version, \
+        self.workflow = name, vendor, description, version, workflow
 
     def set_workflow(self, input_message):
         """

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -97,7 +97,7 @@ class Workflow(object):
                    jobExecutionContextId=input_message.get("jobExecutionContextId", None),
                    time=input_message.get("time", None),
                    connectionTestId=input_message.get("connectionTestId", None),
-                   connectionTestTimeout=input_message.get("connectionTestTimeout", None),
+                   connectionTestTimeout=input_message.get("connectionTestTimeout", None)
                    )
 
 

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -66,6 +66,7 @@ class Plugin(object):
         self.debug = False
         self.custom_decoder = custom_decoder
         self.custom_encoder = custom_encoder
+        self.ouput = None
 
     def add_trigger(self, trigger):
         """ add a new trigger """
@@ -195,7 +196,7 @@ class Plugin(object):
 
         success = True
         ex = None
-        output = None
+        # output = None
         out_type = None
 
         try:
@@ -210,10 +211,10 @@ class Plugin(object):
 
             if message_type == 'action_start':
                 out_type = 'action_event'
-                output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)
+                self.output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)
             elif message_type == 'trigger_start':
                 out_type = 'trigger_event'
-                output = self.start_step(input_message['body'], 'trigger', logger, log_stream, is_test, is_debug)
+                self.output = self.start_step(input_message['body'], 'trigger', logger, log_stream, is_test, is_debug)
         except ClientException as e:
             success = False
             ex = e
@@ -227,11 +228,11 @@ class Plugin(object):
             ex = e
             logger.exception(e)
         finally:
-            output = Plugin.envelope(out_type, input_message, log_stream.getvalue(), success, output,
+            self.output = Plugin.envelope(out_type, input_message, log_stream.getvalue(), success, self.output,
                                      str(ex))
             if not success:
-                raise LoggedException(ex, output)
-            return output
+                raise LoggedException(ex, self.output)
+            return self.output
 
     def start_step(self, message_body, step_key, logger, log_stream, is_test=False, is_debug=False):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='1.0.2',
+      version='1.0.1',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='1.0.1',
+      version='1.0.2',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',


### PR DESCRIPTION
To access the `metadata` of the plugin an attribute meta is added to `connection`.
the information below can be accessed through the `workflow` attribute in `self.connection.meta`


The dict object was created by logging out `self.connetion.meta.workflow.__dict__`

Komand:
```
rapid7/Base64:1.1.2. Step name: decode
{'shortOrgId': None, 'orgProductToken': None, 'uiHostUrl': None, 'jobId': None, 'stepId': None, 'versionId': '3ffe7adf-cb0b-42e2-951a-6963cb41c9bc', 'nextStepId': None, 'nextEdgeId': None, 'triggerId': None, 'jobExecutionContextId': None, 'time': None, 'connectionTestId': None, 'connectionTestTimeout': None, 'workflowUID': '9f235435-69aa-4294-b8cf-f9e91d7bfd4c', 'stepUID': '469c3e14-d495-aa9b-f8ca-3a57c46ec037'}
```

ICON:
```
[2019-02-21 15:47:47 +0000] [1] [INFO] Starting gunicorn 19.7.1
[2019-02-21 15:47:47 +0000] [1] [INFO] Listening at: http://0.0.0.0:10001 (1)
[2019-02-21 15:47:47 +0000] [1] [INFO] Using worker: threads
[2019-02-21 15:47:47 +0000] [10] [INFO] Booting worker with pid: 10
rapid7/Base64:1.1.3. Step name: encode
{'shortOrgId': '09d98d69', 'orgProductToken': None, 'uiHostUrl': None, 'jobId': '69252bbc-69d3-424f-86ad-ec781231f853', 'stepId': '9764be28-017f-439d-ae2d-389bc74a359e', 'versionId': 'b00b0e25-17a3-4085-87bf-117f09c720bc', 'nextStepId': 'db211c37-2a26-4275-b5e3-576d40171f93', 'nextEdgeId': 'c616aaa0-414f-4082-90eb-19d3a2b1b4be', 'triggerId': None, 'jobExecutionContextId': None, 'time': '0001-01-01T00:00:00Z', 'connectionTestId': None, 'connectionTestTimeout': None, 'workflowUID': None, 'stepUID': None}
```

An addition fix was added to `execute_step`, adding `msg` as a param for testing a plugin outside of the docker container.