### PR TITLE
DF-2137: Suppress logging during sampling

### DIFF
--- a/komand/util.py
+++ b/komand/util.py
@@ -86,10 +86,11 @@ def sample(source):
         schema['required'].append(key)
 
 
-    # Get ObjectBuilder logger instance before it runs and suppress it.
+    # Get logger instances before sampling runs and suppress them.
     # This will allow us to generate samples WITHOUT having to grep through the debug messages
-    logger = logging.getLogger("objectbuilder")
-    logger.disabled = True
+    loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+    for logger in loggers:
+        logger.disabled = True
 
     builder = pjs.ObjectBuilder(schema)
     ns = builder.build_classes(strict=True)
@@ -97,7 +98,8 @@ def sample(source):
     o = clazz(**defaults)
 
     # Re-enable logging after we're done
-    logger.disabled = False
+    for logger in loggers:
+        logger.disabled = False
 
     return o.as_dict()
 

--- a/komand/util.py
+++ b/komand/util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import copy
 import sys
+import logging
 
 import python_jsonschema_objects as pjs
 
@@ -84,10 +85,20 @@ def sample(source):
         schema['properties'][key] = prop
         schema['required'].append(key)
 
+
+    # Get ObjectBuilder logger instance before it runs and suppress it.
+    # This will allow us to generate samples WITHOUT having to grep through the debug messages
+    logger = logging.getLogger("objectbuilder")
+    logger.disabled = True
+
     builder = pjs.ObjectBuilder(schema)
     ns = builder.build_classes(strict=True)
     clazz = ns.Example
     o = clazz(**defaults)
+
+    # Re-enable logging after we're done
+    logger.disabled = False
+
     return o.as_dict()
 
 

--- a/komand/util.py
+++ b/komand/util.py
@@ -85,7 +85,6 @@ def sample(source):
         schema['properties'][key] = prop
         schema['required'].append(key)
 
-
     # Get logger instances before sampling runs and suppress them.
     # This will allow us to generate samples WITHOUT having to grep through the debug messages
     loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]


### PR DESCRIPTION
This PR suppresses debug logging in the JSONSchema library while sampling is occurring.

Why do we need this?

During sampling, loads of debug messages are spit out to stdout IN ADDITION to the JSON sample that we want. This warranted the need for an extra `grep` line that only Python plugins needed (Go sampling was just fine, except for the fact that this extra grep line totally broke the `samples` command for Go plugins). This PR will bring the two SDKs in line and reduce the complexity of sample generation.

Testing (outside of the SDK, but same concept):
<img width="669" alt="screen shot 2019-03-04 at 1 27 09 pm" src="https://user-images.githubusercontent.com/32079048/53757429-3efd4600-3e81-11e9-973b-05bbb7c4faa5.png">

Create a logger instance named HELLO. The do_something function will attempt to log a debug message. Outside of the class, grab the logger instance and disable logging. Call the function to debug. No debug message is printed. Re-enable logging. Call the function to debug. Message is printed. 

From the SDK:
<img width="1680" alt="screen shot 2019-03-04 at 3 01 18 pm" src="https://user-images.githubusercontent.com/32079048/53762720-71fa0680-3e8e-11e9-9362-c6c8f83eedf6.png">

