### PR TITLE
DF-2426 | Fix Null or None meta being passed in a plugin

### DIFF
--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -280,7 +280,11 @@ class Plugin(object):
         :param is_debug:
         :return:
         """
-        self.connection.meta.set_workflow(input_message['body'].get('meta', {}))
+        input_message_meta = input_message["body"].get("meta", None)
+
+        if input_message_meta == None:
+            input_message_meta = {}
+        self.connection.meta.set_workflow(input_message_meta)
         request_id = uuid.uuid4()
         log_stream = stream_class()
         stream_handler = logging.StreamHandler(log_stream)

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -280,7 +280,7 @@ class Plugin(object):
         :param is_debug:
         :return:
         """
-        input_message_meta = input_message["body"].get("meta", None)
+        input_message_meta = input_message["body"].get("meta", {})
 
         if input_message_meta == None:
             input_message_meta = {}

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -280,7 +280,7 @@ class Plugin(object):
         :param is_debug:
         :return:
         """
-        self.connection.meta.set_workflow(input_message['body'].get('meta', None))
+        self.connection.meta.set_workflow(input_message['body'].get('meta', {}))
         request_id = uuid.uuid4()
         log_stream = stream_class()
         stream_handler = logging.StreamHandler(log_stream)

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -282,7 +282,7 @@ class Plugin(object):
         """
         input_message_meta = input_message["body"].get("meta", {})
 
-        if input_message_meta == None:
+        if input_message_meta is None:
             input_message_meta = {}
         self.connection.meta.set_workflow(input_message_meta)
         request_id = uuid.uuid4()


### PR DESCRIPTION
When running a test if `meta` is passed as None, you'll get the message below
```
Traceback (most recent call last):
  File "/usr/local/bin/icon_jq", line 4, in <module>
    __import__('pkg_resources').run_script('jq-rapid7-plugin==2.0.4', 'icon_jq')
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1453, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python3.7/site-packages/jq_rapid7_plugin-2.0.4-py3.7.egg/EGG-INFO/scripts/icon_jq", line 32, in <module>
  File "/usr/local/lib/python3.7/site-packages/jq_rapid7_plugin-2.0.4-py3.7.egg/EGG-INFO/scripts/icon_jq", line 28, in main
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/cli.py", line 188, in run
    args.func(args)
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/cli.py", line 138, in run_step
    return self.execute_step(is_test=False, is_debug=args.debug)
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/cli.py", line 126, in execute_step
    output = self.plugin.handle_step(msg, is_test=is_test, is_debug=is_debug)
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py", line 283, in handle_step
    self.connection.meta.set_workflow(input_message['body'].get('meta', None))
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py", line 139, in set_workflow
    if input_message.get("workflow_uid"):
AttributeError: 'NoneType' object has no attribute 'get'
```

To fix this we added a checking in handle_step in the plugin.py to set it to an empty dict.

Before: 
![Screen Shot 2019-03-26 at 5 24 16 PM](https://user-images.githubusercontent.com/32271028/55038051-aaa08200-4fed-11e9-8238-067396d4d9ed.png)

After:
![Screen Shot 2019-03-25 at 3 12 17 PM](https://user-images.githubusercontent.com/32271028/55038067-b3915380-4fed-11e9-8cec-3c5cd577d226.png)
