### PR TITLE
DF-2788: Add new exception presets and an optional data parameter

### DIFF
--- a/komand/exceptions.py
+++ b/komand/exceptions.py
@@ -113,8 +113,10 @@ class ConnectionTestException(Exception):
                 data=self.data
             )
         else:
-            return "Connection test failed!\n\n{cause} {assistance}".format(cause=self.cause,
-                                                                         assistance=self.assistance)
+            return "Connection test failed!\n\n{cause} {assistance}".format(
+                cause=self.cause,
+                assistance=self.assistance
+            )
 
 
 class PluginException(ConnectionTestException):

--- a/komand/exceptions.py
+++ b/komand/exceptions.py
@@ -51,6 +51,10 @@ class ConnectionTestException(Exception):
         NOT_FOUND = "not_found"
         SERVER_ERROR = "server_error"
         SERVICE_UNAVAILABLE = "service_unavailable"
+        INVALID_JSON = "invalid_json"
+        UNKNOWN = "unknown"
+        BASE64_ENCODE = "base64_encode"
+        BASE64_DECODE = "base64_decode"
 
     # Dictionary of cause messages
     causes = {
@@ -60,7 +64,11 @@ class ConnectionTestException(Exception):
         Preset.USERNAME_PASSWORD: "Invalid username or password provided.",
         Preset.NOT_FOUND: "Invalid or unreachable endpoint provided.",
         Preset.SERVER_ERROR: "Server error occurred",
-        Preset.SERVICE_UNAVAILABLE: "The service this plugin is designed for is currently unavailable."
+        Preset.SERVICE_UNAVAILABLE: "The service this plugin is designed for is currently unavailable.",
+        Preset.INVALID_JSON: "Received an unexpected response from the server.",
+        Preset.UNKNOWN: "Something unexpected occurred.",
+        Preset.BASE64_ENCODE: "Unable to base64 encode content due to incorrect padding length.",
+        Preset.BASE64_DECODE: "Unable to base64 decode content due to incorrect padding length."
     }
 
     # Dictionary of assistance/remediation messages
@@ -73,14 +81,19 @@ class ConnectionTestException(Exception):
         Preset.NOT_FOUND: "Verify the endpoint/URL/hostname configured in your plugin connection is correct.",
         Preset.SERVER_ERROR: "Verify your plugin connection inputs are correct and not malformed and try again. "
                              "If the issue persists, please contact support.",
-        Preset.SERVICE_UNAVAILABLE: "Try again later. If the issue persists, please contact support."
+        Preset.SERVICE_UNAVAILABLE: "Try again later. If the issue persists, please contact support.",
+        Preset.INVALID_JSON: "(non-JSON or no response was received).",
+        Preset.UNKNOWN: "Check the logs and if the issue persists please contact support.",
+        Preset.BASE64_ENCODE: "This is likely a programming error, if the issue persists please contact support.",
+        Preset.BASE64_DECODE: "This is likely a programming error, if the issue persists please contact support.",
     }
 
-    def __init__(self, cause=None, assistance=None, preset=None):
+    def __init__(self, cause=None, assistance=None, data=None, preset=None):
         """
         Initializes a new ConnectionTestException. User must supply all punctuation/grammar.
         :param cause: Cause of the error. Leave empty if using preset.
         :param assistance: Possible remediation steps for the error. Leave empty if using preset.
+        :param data: Possible response data related to the error.
         :param preset: Preset error and remediation steps to use.
         """
 
@@ -90,13 +103,31 @@ class ConnectionTestException(Exception):
             self.cause = cause if cause else ""
             self.assistance = assistance if assistance else ""
 
+        self.data = data if data else ""
+
     def __str__(self):
-        return "Connection test failed! {cause} {assistance}".format(cause=self.cause,
-                                                                     assistance=self.assistance)
+        if self.data:
+            return "Connection test failed!\n\n{cause} {assistance} Response was: {data}".format(
+                cause=self.cause,
+                assistance=self.assistance,
+                data=self.data
+            )
+        else:
+            return "Connection test failed!\n\n{cause} {assistance}".format(cause=self.cause,
+                                                                         assistance=self.assistance)
 
 
 class PluginException(ConnectionTestException):
 
     def __str__(self):
-        return "An error occurred during plugin execution! {cause} {assistance}".format(cause=self.cause,
-                                                                                        assistance=self.assistance)
+        if self.data:
+            return "An error occurred during plugin execution!\n\n{cause} {assistance} Response was: {data}".format(
+                cause=self.cause,
+                assistance=self.assistance,
+                data=self.data
+            )
+        else:
+            return "An error occurred during plugin execution!\n\n{cause} {assistance}".format(
+                cause=self.cause,
+                assistance=self.assistance
+            )


### PR DESCRIPTION
## Description

* Add new presets: `UNKNOWN`, `BASE64_ENCODE`, `BASE64_DECODE`, `INVALID_JSON`
* Add an optional `data` parameter for formatting response output

## Tests

```
msg = 'blah'
raise PluginException(preset=PluginException.Preset.BASE64_ENCODE, data=msg)

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/plugin.py", line 311, in handle_step
    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/plugin.py", line 413, in start_step
    output = func(params)
  File "build/bdist.linux-x86_64/egg/icon_crap/actions/upper/action.py", line 20, in run
    data=msg
PluginException: An error occurred during plugin execution!

Unable to base64 encode content due to incorrect padding length. This is likely a programming error, if the issue persists please contact support. Response was: blah
```

```
msg = 'blah'
raise PluginException(preset=PluginException.Preset.BASE64_DECODE, data=msg)

Traceback (most recent call last):
  File "/usr/local/bin/icon_crap", line 4, in <module>
    __import__('pkg_resources').run_script('crap-rapid7-plugin==1.0.0', 'icon_crap')
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1460, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python2.7/site-packages/crap_rapid7_plugin-1.0.0-py2.7.egg/EGG-INFO/scripts/icon_crap", line 38, in <module>

  File "/usr/local/lib/python2.7/site-packages/crap_rapid7_plugin-1.0.0-py2.7.egg/EGG-INFO/scripts/icon_crap", line 34, in main

  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/cli.py", line 188, in run
    args.func(args)
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/cli.py", line 138, in run_step
    return self.execute_step(is_test=False, is_debug=args.debug)
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/cli.py", line 135, in execute_step
    raise exception
komand.exceptions.LoggedException: An error occurred during plugin execution!

Unable to base64 decode content due to incorrect padding length. This is likely a programming error, if the issue persists please contact support. Response was: blah
```

```
msg = 'Unknown data'
raise PluginException(preset=PluginException.Preset.UNKNOWN, data=msg)

Traceback (most recent call last):
  File "/usr/local/bin/icon_crap", line 4, in <module>
    __import__('pkg_resources').run_script('crap-rapid7-plugin==1.0.0', 'icon_crap')
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1460, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python2.7/site-packages/crap_rapid7_plugin-1.0.0-py2.7.egg/EGG-INFO/scripts/icon_crap", line 38, in <module>

  File "/usr/local/lib/python2.7/site-packages/crap_rapid7_plugin-1.0.0-py2.7.egg/EGG-INFO/scripts/icon_crap", line 34, in main

  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/cli.py", line 188, in run
    args.func(args)
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/cli.py", line 138, in run_step
    return self.execute_step(is_test=False, is_debug=args.debug)
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/cli.py", line 135, in execute_step
    raise exception
komand.exceptions.LoggedException: An error occurred during plugin execution!

Something unexpected occurred. Check the logs and if the issue persists please contact support. Response was: Unknown data
```

```
msg = '{ \"asdf\": asdf }'
raise PluginException(preset=PluginException.Preset.UNKNOWN, data=msg)

Traceback (most recent call last):
  File "/usr/local/bin/icon_crap", line 4, in <module>
    __import__('pkg_resources').run_script('crap-rapid7-plugin==1.0.0', 'icon_crap')
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1460, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python2.7/site-packages/crap_rapid7_plugin-1.0.0-py2.7.egg/EGG-INFO/scripts/icon_crap", line 38, in <module>

  File "/usr/local/lib/python2.7/site-packages/crap_rapid7_plugin-1.0.0-py2.7.egg/EGG-INFO/scripts/icon_crap", line 34, in main

  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/cli.py", line 188, in run
    args.func(args)
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/cli.py", line 138, in run_step
    return self.execute_step(is_test=False, is_debug=args.debug)
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/cli.py", line 135, in execute_step
    raise exception
komand.exceptions.LoggedException: An error occurred during plugin execution!

Received an unexpected response from the server. (non-JSON or no response was received). Response was: { "asdf": asdf }
```

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/plugin.py", line 311, in handle_step
    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/plugin.py", line 413, in start_step
    output = func(params)
  File "build/bdist.linux-x86_64/egg/icon_crap/actions/lower/action.py", line 21, in run
    data=msg
PluginException: An error occurred during plugin execution!

Something caused this. I don't have assistance but I have data! Response was: Blah
```

* Without `data`

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/plugin.py", line 311, in handle_step
    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)
  File "/usr/local/lib/python2.7/site-packages/komand-1.0.1-py2.7.egg/komand/plugin.py", line 413, in start_step
    output = func(params)
  File "build/bdist.linux-x86_64/egg/icon_crap/actions/split_to_list/action.py", line 19, in run
    assistance="I don't have assistance"
PluginException: An error occurred during plugin execution!

Something caused this. I don't have assistance
```