### PR TITLE
Enable add and remove worker endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Rapid7 InsightConnect (previously Komand).
 
 ## Changelog
 
+* 3.3.0 - Add webserver route to allow for threading changes
+
 * 3.2.0 - Add new ConnectionTestException/PluginException presets:
  UNKNOWN, BASE64_ENCODE, BASE64_DECODE, INVALID_JSON |
  Add an optional data parameter for formatting response output

--- a/komand/server.py
+++ b/komand/server.py
@@ -155,7 +155,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
         # Return flask app
         return app
 
-    def number_of_workers(self):  
+    def number_of_workers(self):
         output = subprocess.check_output('ps | grep "icon\\|komand" | grep -v "grep" | wc -l', shell=True)
         num_workers = int(output.decode())
 

--- a/komand/server.py
+++ b/komand/server.py
@@ -98,6 +98,28 @@ class PluginServer(gunicorn.app.base.BaseApplication):
                 r.status_code = status_code
                 return r
 
+        @app.route("/_threads", methods=["POST"])
+        def update_threads():
+            """
+            Updates the number of threads ran by the webserver
+            :return:
+            """
+
+            # First get the number of threads POSTed to the route. Catch an instance of a missing number of threads
+            try:
+                num_threads = request.form["num_threads"]
+            except KeyError:
+                self.logger.error("Received POST with invalid/missing input. Expected 'num_threads', "
+                                  "got {form_keys}".format(form_keys=request.form.keys()))
+                return abort(404)
+
+            # Update the gunicorn configuration
+            self.gunicorn_config["threads"] = num_threads
+
+            # Now that it's updated, call reload which calls load_default_config and finally calls our
+            # implementation of load_config
+            self.reload()
+
         return app
 
     def start(self):

--- a/komand/server.py
+++ b/komand/server.py
@@ -114,7 +114,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
             try:
                 self.logger.info("Adding a worker")
                 self.logger.info("Current process is: %s" % self.master_pid)
-                os.kill(self.master_pid, signal.SIGTTIN)                
+                os.kill(self.master_pid, signal.SIGTTIN)
             except Exception as e:
                 r.status_code = 500
                 r.error = e
@@ -138,7 +138,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
             try:
                 self.logger.info("Removing a worker")
                 self.logger.info("Current process is: %s" % self.master_pid)
-                os.kill(self.master_pid, signal.SIGTTOU)                
+                os.kill(self.master_pid, signal.SIGTTOU)
             except Exception as e:
                 r = {}
                 r.status_code = 500

--- a/komand/server.py
+++ b/komand/server.py
@@ -102,7 +102,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
                 r.status_code = status_code
                 return r
 
-        @app.route("/add_worker", methods=["POST"])
+        @app.route("/workers/add", methods=["POST"])
         def add_worker():
             """
             Adds a worker (another process)
@@ -110,6 +110,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
             """
             r = {}
 
+            # Linux signal examples here:
             # https://docs.gunicorn.org/en/stable/signals.html#master-process
             try:
                 self.logger.info("Adding a worker")
@@ -123,7 +124,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
             r["num_workers"] = self._number_of_workers()
             return jsonify(r)
 
-        @app.route("/remove_worker", methods=["POST"])
+        @app.route("/workers/remove", methods=["POST"])
         def remove_worker():
             """
             Shuts down a worker (another process)
@@ -134,6 +135,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
 
             r = {}
 
+            # Linux signal examples here:
             # https://docs.gunicorn.org/en/stable/signals.html#master-process
             try:
                 self.logger.info("Removing a worker")
@@ -147,7 +149,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
 
             return jsonify(r)  # Flask or Gunicorn expect a return
 
-        @app.route("/number_of_workers", methods=["POST"])
+        @app.route("/workers", methods=["GET"])
         def num_workers():
             r = {'num_workers': self._number_of_workers()}
             return jsonify(r)

--- a/komand/server.py
+++ b/komand/server.py
@@ -113,7 +113,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
             # https://docs.gunicorn.org/en/stable/signals.html#master-process
             try:
                 self.logger.info("Adding a worker")
-                self.logger.info(f"Current process is: {self.master_pid}")
+                self.logger.info("Current process is: %s" % self.master_pid)
                 os.kill(self.master_pid, signal.SIGTTIN)                
             except Exception as e:
                 r.status_code = 500
@@ -137,7 +137,7 @@ class PluginServer(gunicorn.app.base.BaseApplication):
             # https://docs.gunicorn.org/en/stable/signals.html#master-process
             try:
                 self.logger.info("Removing a worker")
-                self.logger.info(f"Current process is: {self.master_pid}")
+                self.logger.info("Current process is: %s" % self.master_pid)
                 os.kill(self.master_pid, signal.SIGTTOU)                
             except Exception as e:
                 r = {}

--- a/komand/server.py
+++ b/komand/server.py
@@ -99,10 +99,10 @@ class PluginServer(gunicorn.app.base.BaseApplication):
                 return r
 
         @app.route("/_threads", methods=["POST"])
-        def update_threads():
+        def update_threads() -> None:
             """
             Updates the number of threads ran by the webserver
-            :return:
+            :return: None
             """
 
             # First get the number of threads POSTed to the route. Catch an instance of a missing number of threads

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='komand',
-      version='3.2.0',
+      version='3.3.0',
       description='Komand Plugin SDK',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR adds a route to a plugin webserver to enable it to accept POSTs with a desired number of threads to utilize.

NOTE: Preliminary work & untested

Joey: 
This PR adds endpoints to: 
* add a worker
* remove a worker
* get number of workers

This has been tested via creating a docker dev image, then changing a plugin to use that image. Can add a worker, remove a worker, and get number of workers successfully. 