### PR TITLE
Implement test to validate swagger spec generation

### DIFF
--- a/komand/server.py
+++ b/komand/server.py
@@ -404,21 +404,25 @@ class PluginServer(gunicorn.app.base.BaseApplication):
         # num_workers - 1 due to a master process being run as well
         return num_workers - 1
 
+    def register_api_spec(self):
+        """ Register all swagger schema definitions and path objects """
+        self.spec.components.schema('PluginInfo', schema=PluginInfoSchema)
+        self.spec.path(view=self.app.view_functions["api_spec"])
+        self.spec.path(view=self.app.view_functions["plugin_info"])
+        self.spec.path(view=self.app.view_functions["plugin_spec"])
+        self.spec.path(view=self.app.view_functions["actions"])
+        self.spec.path(view=self.app.view_functions["triggers"])
+        self.spec.path(view=self.app.view_functions["status"])
+        self.spec.path(view=self.app.view_functions["action_run"])
+        self.spec.path(view=self.app.view_functions["action_test"])
+        self.spec.path(view=self.app.view_functions["trigger_test"])
+
     def start(self):
         """ start server """
         with self.app.app_context():
             try:
                 arbiter = Arbiter(self)
-                self.spec.components.schema('PluginInfo', schema=PluginInfoSchema)
-                self.spec.path(view=self.app.view_functions["api_spec"])
-                self.spec.path(view=self.app.view_functions["plugin_info"])
-                self.spec.path(view=self.app.view_functions["plugin_spec"])
-                self.spec.path(view=self.app.view_functions["actions"])
-                self.spec.path(view=self.app.view_functions["triggers"])
-                self.spec.path(view=self.app.view_functions["status"])
-                self.spec.path(view=self.app.view_functions["action_run"])
-                self.spec.path(view=self.app.view_functions["action_test"])
-                self.spec.path(view=self.app.view_functions["trigger_test"])
+                self.register_api_spec()
 
                 self.logger = arbiter.log
                 arbiter.run()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(name='komand',
       tests_require=[
           'pytest',
           'docker',
-          'dockerpty'
+          'dockerpty',
+          'swagger-spec-validator'
       ],
       extras_require={
           ':python_version == "2.7"': ['futures']

--- a/tests/unit/test_server_spec.py
+++ b/tests/unit/test_server_spec.py
@@ -1,0 +1,9 @@
+from komand import server
+from swagger_spec_validator.validator20 import validate_spec
+
+
+def test_validate_server_spec():
+    plugin_server = server.PluginServer("test")
+    with plugin_server.app.test_request_context():
+        plugin_server.register_api_spec()
+        validate_spec(plugin_server.spec.to_dict())

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     futures
     docker
     dockerpty
+    swagger-spec-validator
 commands=
     pytest --pep8 --cov=komand {posargs}
     coverage html


### PR DESCRIPTION
Implement test to validate swagger spec generation to ensure it matches expected schema

This currently results in a failure since there are two changes needed (in another PR):
```
tests/unit/test_server_spec.py .F                                                                                                                                                                                                         [100%]

=================================================================================================================== FAILURES ====================================================================================================================
___________________________________________________________________________________________________________ test_validate_server_spec ___________________________________________________________________________________________________________

    def test_validate_server_spec():
        plugin_server = server.PluginServer("test")
        with plugin_server.app.test_request_context():
            plugin_server.register_api_spec()
>           validate_spec(plugin_server.spec.to_dict())

tests/unit/test_server_spec.py:9: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.tox/py38/lib/python3.8/site-packages/swagger_spec_validator/validator20.py:170: in validate_spec
    validate_apis(apis, bound_deref)
.tox/py38/lib/python3.8/site-packages/swagger_spec_validator/validator20.py:388: in validate_apis
    validate_responses(api_name, oper_name, oper_body['responses'], deref)
.tox/py38/lib/python3.8/site-packages/swagger_spec_validator/validator20.py:278: in validate_responses
    validate_definition(
.tox/py38/lib/python3.8/site-packages/swagger_spec_validator/validator20.py:494: in validate_definition
    validate_arrays_in_definition(definition, def_name=def_name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

definition_spec = {'type': 'array'}, def_name = '#/paths//actions/get/responses/200'

    def validate_arrays_in_definition(definition_spec, def_name=None):
        if definition_spec.get('type') == 'array' and 'items' not in definition_spec:
>           raise SwaggerValidationError(
                'Definition of type array must define `items` property{}.'.format(
                    '' if not def_name else ' (definition {})'.format(def_name),
                ),
            )
E           swagger_spec_validator.common.SwaggerValidationError: Definition of type array must define `items` property (definition #/paths//actions/get/responses/200).

.tox/py38/lib/python3.8/site-packages/swagger_spec_validator/validator20.py:449: SwaggerValidationError
```